### PR TITLE
generate keypair name

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,4 +1,4 @@
-name: 'Terraform CI'
+name: 'Jitsi module CI'
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     
 jobs:
   terraform:
-    name: 'Terraform'
+    name: 'Jitsi module CI'
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,9 +33,14 @@ jobs:
     steps:
     - name: Generate SSH Keypair name
       run: echo TF_VAR_KEYPAIR_NAME=module-jitsi-test-$(uuidgen) >> $GITHUB_ENV
+
+    - name: Generate Subdomain name
+      run : echo TF_VAR_DNS_SUBDOMAIN=${TF_VAR_DNS_SUBDOMAIN}-$(uuidgen) >> $GITHUB_ENV
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v2
+
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
@@ -62,7 +67,7 @@ jobs:
     - name: Test Jisti web service
       uses: jtalk/url-health-check-action@v2
       with:
-        url: http://${{ secrets.DNS_SUBDOMAIN }}.${{ secrets.DNS_ZONE }}
+        url: http://${{ env.TF_VAR_DNS_SUBDOMAIN }}.${{ secrets.DNS_ZONE }}
         follow-redirect: false
         max-attempts: 30
         retry-delay: 30s

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,6 +31,8 @@ jobs:
         shell: bash
         
     steps:
+    - name: Generate SSH Keypair name
+      run: echo TF_VAR_KEYPAIR_NAME=module-jitsi-test-$(uuidgen) >> $GITHUB_ENV
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v2
@@ -62,10 +64,10 @@ jobs:
       with:
         url: http://${{ secrets.DNS_SUBDOMAIN }}.${{ secrets.DNS_ZONE }}
         follow-redirect: false
-        max-attempts: 15
+        max-attempts: 30
         retry-delay: 30s
         retry-all: true
-      timeout-minutes: 10
+      timeout-minutes: 15
 
     - name: Terraform Destroy
       if: always()  # Run even on previous step failure

--- a/tests/staging/test_staging.tf
+++ b/tests/staging/test_staging.tf
@@ -23,7 +23,7 @@ provider "gandi" {}
 module "gandi-jitsi" {
   source              = "../.."
   server_name         = "gandi-jitsi"
-  keypair_name        = "module-jitsi-test"
+  keypair_name        = var.KEYPAIR_NAME
   letsencrypt_email   = "email@example.invalid"
   letsencrypt_staging = "1"
   dns_subdomain       = var.DNS_SUBDOMAIN
@@ -35,5 +35,9 @@ variable "DNS_SUBDOMAIN" {
 }
 
 variable "DNS_ZONE" {
+  type = string
+}
+
+variable "KEYPAIR_NAME" {
   type = string
 }


### PR DESCRIPTION
This enables the CI to run more than one instance at the same time as OpenStack does not handle having multiple keypairs with the same name.